### PR TITLE
Fix embedding computation

### DIFF
--- a/src/clamp/embeds.py
+++ b/src/clamp/embeds.py
@@ -99,10 +99,12 @@ def next_token_embed(
         raise ValueError(f"Empty guess: {guess!r}")
     preamble_w_guess = f"{preamble} {guess}"
     # tokenize new complete sentence
-    tokenized = tokenizer(
-        preamble_w_guess, add_special_tokens=True, return_tensors="pt"
-    ).to(model.device)
+    tokenized = tokenizer(preamble_w_guess, add_special_tokens=True, return_tensors="pt").to(
+        model.device
+    )
     start_idx = tokenized.char_to_token(0, len(preamble_w_guess) - len(guess))
+    if start_idx is None:
+        raise ValueError(f"Tokenization error for preamble {preamble!r} with guess {guess!r}")
     embeds = model(**tokenized, output_hidden_states=True).hidden_states
     last_token_embed = embeds[layer][0, start_idx, :]
     return last_token_embed

--- a/src/clamp/embeds.py
+++ b/src/clamp/embeds.py
@@ -78,11 +78,13 @@ def main(
 
 
 def load_embeddings(embeddings_file: str | pathlib.Path) -> pl.DataFrame:
+    # FIXME: what if the prediction file is missing the extra columns?
     return pl.read_parquet(
         embeddings_file, columns=["preamble", "token_id", "guess", "logit", "embedding"]
     )
 
 
+# FIXME: batch this
 @torch.inference_mode()
 def next_token_embed(
     preamble: str,
@@ -92,11 +94,16 @@ def next_token_embed(
     layer: int,
 ) -> torch.Tensor:
     """Get embeddings for ONE preamble/guess pair"""
+    # This doesn't nearly catch all subtle tokenization gotchas but it's something
+    if len(guess) == 0 or guess.isspace():
+        raise ValueError(f"Empty guess: {guess!r}")
     # FIXME: we shouldn't need to tokenize twice I think
-    start_ix = len(tokenizer(preamble)["input_ids"])
-    preamble_w_guess = preamble + guess
+    start_ix = tokenizer(preamble, add_special_tokens=True).char_to_token(0, len(preamble) - 1) + 1
+    preamble_w_guess = f"{preamble} {guess}"
     # tokenize new complete sentence
-    new_preamble_tokenized = tokenizer(preamble_w_guess, return_tensors="pt").to(model.device)
+    new_preamble_tokenized = tokenizer(
+        preamble_w_guess, add_special_tokens=True, return_tensors="pt"
+    ).to(model.device)
     embeds = model(**new_preamble_tokenized, output_hidden_states=True).hidden_states
     last_token_embed = embeds[layer][0, start_ix, :]
     return last_token_embed

--- a/src/clamp/embeds.py
+++ b/src/clamp/embeds.py
@@ -102,9 +102,9 @@ def next_token_embed(
     tokenized = tokenizer(
         preamble_w_guess, add_special_tokens=True, return_tensors="pt"
     ).to(model.device)
-    start_ix = tokenized.char_to_token(0, len(preamble) - len(guess))
+    start_idx = tokenized.char_to_token(0, len(preamble_w_guess) - len(guess))
     embeds = model(**tokenized, output_hidden_states=True).hidden_states
-    last_token_embed = embeds[layer][0, start_ix, :]
+    last_token_embed = embeds[layer][0, start_idx, :]
     return last_token_embed
 
 

--- a/src/clamp/embeds.py
+++ b/src/clamp/embeds.py
@@ -97,14 +97,13 @@ def next_token_embed(
     # This doesn't nearly catch all subtle tokenization gotchas but it's something
     if len(guess) == 0 or guess.isspace():
         raise ValueError(f"Empty guess: {guess!r}")
-    # FIXME: we shouldn't need to tokenize twice I think
-    start_ix = tokenizer(preamble, add_special_tokens=True).char_to_token(0, len(preamble) - 1) + 1
     preamble_w_guess = f"{preamble} {guess}"
     # tokenize new complete sentence
-    new_preamble_tokenized = tokenizer(
+    tokenized = tokenizer(
         preamble_w_guess, add_special_tokens=True, return_tensors="pt"
     ).to(model.device)
-    embeds = model(**new_preamble_tokenized, output_hidden_states=True).hidden_states
+    start_ix = tokenized.char_to_token(0, len(preamble) - len(guess))
+    embeds = model(**tokenized, output_hidden_states=True).hidden_states
     last_token_embed = embeds[layer][0, start_ix, :]
     return last_token_embed
 


### PR DESCRIPTION
This fixes two major issues on embedding computation

- Space were not being added being preambles and guesses
- Indexing was wrong for models with special tokens

Fortunately this does not affect the published results, since these used another version of embeddings computing.

Silver lining: the fix for these issues actually removes the annoying extra tokenisation step, so it should make embed a smidge faster.