### PR TITLE
Fix CI on macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           clamp cluster --covariance-type diag --progress 10 data/generated/pythia_14m_last_layer-embeddings.parquet data/generated/pythia_14m_last_layer-clusters.tsv
       - name: Run tox
         run: |
-          uv tool install tox --with tox-gh-actions --with tox-uv
+          uv tool install --python ${{ matrix.python-version }} tox --with tox-gh-actions --with tox-uv
           tox -- -v --durations=0
       - name: Upload hypothesis examples database
         uses: actions/upload-artifact@v4

--- a/tox.toml
+++ b/tox.toml
@@ -1,5 +1,5 @@
 minversion = "4"
-env_list = ["py312", "py311", "py310"]
+env_list = ["py313", "py312", "py311", "py310"]
 isolated_build = true
 skip_missing_interpreters = true
 
@@ -20,4 +20,5 @@ commands = [
 python = """
 3.10: py310
 3.11: py311
-3.12: py312"""
+3.12: py312
+3.12: py313"""


### PR DESCRIPTION
Mac os switching to Python 3.14 broke CI on there, this makes the tox python version explicit to unbreak it. 